### PR TITLE
Alphabetize category and tag tabs

### DIFF
--- a/_includes/categories-tab.html
+++ b/_includes/categories-tab.html
@@ -1,6 +1,7 @@
 <div class="tab">
   <ul class="cards">
-    {% for category in site.categories %}
+  {% assign cat_list = site.categories | sort %}
+    {% for category in cat_list %}
       {% assign cat_name = category | first %}
       <li class="card">
         <a class="card__link" href="{{ site.baseurl }}/place/{{ category | first | downcase | slugify }}/">

--- a/_includes/tags-tab.html
+++ b/_includes/tags-tab.html
@@ -1,6 +1,7 @@
 <div class="tab">
   <ul class="cards">
-    {% for tag in site.tags %}
+  {% assign tag_list = site.tags | sort %}
+    {% for tag in tag_list %}
       {% assign tag_name = tag | first %}
       <li class="card">
         <a class="card__link" href="{{ site.baseurl }}/people/{{ tag | first | downcase | slugify }}/">


### PR DESCRIPTION
I noticed that the Logbook currently displays categories and tags in chronological order on those tabs. I added a couple lines of Liquid to the `_includes/categories-tab.html` and `_includes/tags-tab.html` files so that categories and tabs will be displayed in alphabetical order instead.