### PR TITLE
Exclude "vendor" from build

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,7 +14,7 @@ default_img:
 
 # Build settings
 include: ["_categories"]
-exclude: ["_screenshots", "Gemfile", "Gemfile.lock"]
+exclude: ["_screenshots", "Gemfile", "Gemfile.lock", "vendor"]
 markdown: kramdown
 permalink: /entries/:year-:month-:day-:title/
 


### PR DESCRIPTION
Otherwise we bump into this bug while running "jekyll build":
https://github.com/jekyll/jekyll/issues/2938

This is due to the fact that some people will create their bundle envs within their repo rather than globally.